### PR TITLE
Succesful creation of artifact on gefion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,128 @@
 # MLWM Deployment
 Deployment repository for DMIs MLWMs (Machine Learning Weather Model).
 
+This repository was designed with the following constraints in mind:
+
+- Individual forecast runs must be executed within isolated container
+  environments.
+- This repository must contain the configuration of which pretrained models to
+  run for each forecasting run, with a clear process for how to add new pretrained
+  models.
+- This repository must contain a python package (named `mlwm`) to be used
+  for
+    1. packaging up everything needed for inference from the computer where a
+       model was trained on (we call this creating an *inference artifact*)
+    2. continuous integration tooling that builds container images that will be
+       used for inference
+    3. CLI for executing all model inferences configured in this repository.
+    
+## Adding a new pretrained model for scheduled forecasting
+
+The process of adding a new model to be executed as part of the set of models
+run for each forecast cycle is as follows:
+
+1. Create an **inference artifact** and upload to the mlwm inference artifact
+   repository (`s3://mlwm-artifacts/`) on the machine where you trained the
+   model. This contains everything needed to run the forecast inference (model
+   weights, model configuration, dataset statistics). This is done with
+   `wlwm.build_inference_artifact`. If you are on an airgapped system you can
+   upload the inference artifact zip-file manually.
+2. Add configuration to mlwm deployment repository (the repository you are
+   looking at right now) which describes how to build an inference container
+   image from the inference artifact you created above.
+
 This repository contains the deployment scripts and configuration files for deploying the MLWM models. All models are stored as container images and have an assumption of being deployed in a containerized environment. The containers are assuming the same structure of input data.
+
+
+### Building inference artifact on machine that was trained on
+
+The purpose of building an **inference artifact** is to collect all the information that is needed to run model inference later.
+
+This includes:
+
+- model checkpoint (with the weights)
+- model configuration (i.e. the neural-lam and datastore config yaml-files)
+- the training arguments (i.e. command line arguments used during training)
+- statistics of the training dataset (used for standardization)
+
+With the `mlwm.build_inference_artifact` command, you can build an inference artifact zip-file and upload this to the DMI S3 bucket for inference artifacts (`s3://mlwm-artifacts/inference-artifacts/`). Before running this command you must make a yaml-file containing the command-line arguments you used during training, e.g.:
+
+```yaml
+# training_cli_args.yaml
+- num_workers: 6
+- precision: bf16-mixed
+- batch_size: 1
+- hidden_dim: 300
+- hidden_dim_grid: 150
+- time_delta_enc_dim: 32
+- config_path: ${CONFIG}
+- model: hi_lam
+- processor_layers: 2
+- graph_name: 2dfeat_7deg_tri_9s_hi3
+- num_nodes: $SLURM_JOB_NUM_NODES
+- epochs: 80
+- ar_steps_train: 1
+- lr: 0.001
+- min_lr: 0.001
+- val_interval: 5
+- ar_steps_eval: 4
+- val_steps_to_log: 1 2 4
+```
+
+When you build the inference artifact you need to give it a name (in the example below this is `gefion-1`), the resulting artifact zip file will then be named `<name>.zip`. This name is simply used to identify the artifact and is not necessarily related to any forecasting container image built later.
+
+To build the inference artifact you run `mlwm.build_inference_artifact`, for example:
+
+```bash
+uv run python -m mlwm.build_inference_artifact gefion-1 \
+--nl_config /dcai/projects/cu_0003/user_space/hinkas/git-repos/ablation-studies/configs/danra_model1/7deg_config.yaml \
+--cli_training_args_filepath /dcai/projects/cu_0003/user_space/hinkas/git-repos/mllam/mlwm-deployment/config.yaml \
+--checkpoint /dcai/projects/cu_0003/user_space/hinkas/models_for_inf/train-hi_lam-2x300-02_27_15-4034/last.ckpt
+```
+
+The contents of the zip-file will be:
+
+```bash
+gefion-1/
+├── artifact.yaml
+├── checkpoint.pkl
+├── configs
+│   ├── config.yaml
+│   └── danra.datastore.yaml
+├── stats
+│   └── danra.datastore.stats.zarr
+└── training_cli_args.yaml
+```
+
+`artifact.yaml` contains information about how the inference artifact was built, i.e. the command line arguments used to build the artifact, e.g. system information, and the command line arguments used to invocate the cli.
+
+### Adding a new model configuration
+
+> TBC: This functionality is not yet complete, so the information written below is subject to change.
+
+Model configurations are stored in this repository (in `configurations/{model_name}`). Each configuration should be comprised of three things:
+1. A README describing the inference setup. Ideally, this will include things like notes on how the model was trained and what makes the model special.
+2. The inference artifact URI (this contains all information required from training to execute the model for inference).
+3. A Containerfile to build the inference container image from.
+
+### Executing the configured forecasting models
+
+> TBC: This functionality is not yet complete, so the information written below is subject to change.
+
+To execute the forecasting models configured in this repo run:
+
+`uv run python -m mlwm.run_models`
+
+Internally, the execution works as follows:
+
+- for each model configured in this repository (stored in `configurations/{model_name}`):
+    - read the model configuration .yaml file (stored in `configurations/{model_name}/config.yaml`)
+    - copy the required input zarr datasets from the s3 locations described in the configuration file, this will be to `$WORKDIR/input/{model_name}/{input_name}`. These will be parameterised by the `analysis_time` of the execution
+    - create the output directorie(s) for the model, this will be `$WORKDIR/output/{model_name}/{output_name}`
+    - launch the docker container for the model, mounting the input and output directories as volumes to the container
+    - wait for the container to finish running
+    - copy the output directories to the s3 locations given in the model configuration, again these will be parameterised by the `analysis_time`
+
 
 ## Data Directory Structure
 Input data is following a structure that contains a list of traditional weather model identifiers:
@@ -47,63 +168,3 @@ parsed_components = mlwm_paths.parse_path(path)
 More examples can be found in [`mlwm/tests/test_paths.py`](src/mlwm/tests/test_paths.py).
 
 `<member>` is the number of the ensemble member, with 0 being the control run following the format `member<member>`, like `member0`.
-
-
-## Building inference artifact on machine that was trained on
-
-The purpose of building an **inference artifact** is to collect all the information that is needed to run model inference later.
-
-This includes:
-
-- model checkpoint (with the weights)
-- model configuration (i.e. the neural-lam and datastore config yaml-files)
-- the training arguments (i.e. command line arguments used during training)
-- statistics of the training dataset (used for standardization)
-
-With the `mlwm.build_inference_artifact` command, you can build an inference artifact zip-file and upload this to the DMI S3 bucket for inference artifacts (`s3://mlwm-artifacts/inference-artifacts/`). Before running this command you must make a yaml-file containing the command-line arguments you used during training, e.g.:
-
-```yaml
-# training_cli_args.yaml
-- num_workers: 6
-- precision: bf16-mixed
-- batch_size: 1
-- hidden_dim: 300
-- hidden_dim_grid: 150
-- time_delta_enc_dim: 32
-- config_path: ${CONFIG}
-- model: hi_lam
-- processor_layers: 2
-- graph_name: 2dfeat_7deg_tri_9s_hi3
-- num_nodes: $SLURM_JOB_NUM_NODES
-- epochs: 80
-- ar_steps_train: 1
-- lr: 0.001
-- min_lr: 0.001
-- val_interval: 5
-- ar_steps_eval: 4
-- val_steps_to_log: 1 2 4
-```
-
-When you build the inference artifact you need to give it a name (in the example below this is `gefion-1`), the resulting artifact zip file will then be named `<name>.zip`. This name is simply used to identify the artifact and is not necessarily related to any forecasting container image built later.
-
-To build the inference artifact you run `mlwm.build_inference_artifact`, for example:
-
-```bash
-uv run python -m mlwm.build_inference_artifact gefion-1 --nl_config config.yaml --checkpoint train-graph_lam-4x2-01_24_14-5078/min_val_loss.ckp
-```
-
-The contents of the zip-file will be:
-
-```bash
-gefion-1/
-├── artifact.yaml
-├── checkpoint.pkl
-├── configs
-│   ├── config.yaml
-│   └── danra.datastore.yaml
-├── stats
-│   └── danra.datastore.stats.zarr
-└── training_cli_args.yaml
-```
-
-`artifact.yaml` contains information about how the inference artifact was built, i.e. the command line arguments used to build the artifact, e.g. system information, and the command line arguments used to invocate the cli.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlwm-deployment"
 dynamic = ["version"]
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "parse>=1.20.2",
     "dask>=2025.4.1",
@@ -15,7 +15,7 @@ dependencies = [
     "s3fs>=2025.3.2",
     "tqdm>=4.67.1",
     "universal-pathlib>=0.2.6",
-    "zarr>=3.0",
+    "zarr",
 ]
 
 [dependency-groups]

--- a/src/mlwm/build_inference_artifact.py
+++ b/src/mlwm/build_inference_artifact.py
@@ -398,6 +398,7 @@ def main():
         logger.info(
             "You opted to skip uploading the inference artifact to the S3 host."
             f" You will have to upload it to {fp_artifact_target} manually."
+            f" The built inference artifact is stored in {fp_artifact_local}"
         )
 
 

--- a/src/mlwm/build_inference_artifact.py
+++ b/src/mlwm/build_inference_artifact.py
@@ -86,7 +86,10 @@ def _find_datastore_paths(nl_config_path: str) -> Dict[str, str]:
                 datastore_config["config_path"]
             )
     else:
-        raise ValueError("No datastore found in the config file.")
+        raise ValueError(
+            "No datastore found in the config file. Are you sure you "
+            "have provided the path to a valid neural-lam config file?"
+        )
 
     return datastore_paths
 
@@ -184,6 +187,7 @@ def _copy_yaml_configs(nl_config_path: str, artifact_output_path: str):
     artifact_output_path = Path(artifact_output_path) / "configs"
     artifact_output_path.mkdir(parents=True, exist_ok=True)
 
+    logger.debug(f"Opening neural-lam config in {Path(nl_config_path).absolute()}")
     nl_config = yaml.safe_load(open(nl_config_path, "r"))
 
     datastore_config_paths = _find_datastore_paths(nl_config_path)
@@ -218,41 +222,45 @@ def _copy_yaml_configs(nl_config_path: str, artifact_output_path: str):
     logger.debug(f"Copied {nl_config_path} -> {fp_config_dst}")
 
 
-def _check_and_copy_training_cli_args(artifact_output_path: str):
+def _copy_training_cli_args(artifact_output_path: str, training_cli_args_filepath: str):
     """
-    Check for the presence of a file called `training_cli_args.yaml` in the
-    current directory, check that it is a valid yaml file, and copy it to the
-    artifact output directory.
+    Check for the presence of a file that stores the CLI args used during
+    training, check that it is a valid yaml file, and copy it to the artifact
+    output directory. The file with the CLI training args will have a hardcoded
+    filename within the artifact so that we can refer to it later.
 
     Parameters
     ----------
     artifact_output_path : str
         Path to the artifact output directory.
+    training_cli_args_filepath: str
+        Path to the file containing the command line arguments that were used
+        during training. NB: At some point in future hopefully all training
+        arguments that effect inference should be used to the neural-lam config
+        file so that we don't need to provide this command line arguments
+        separately.
     """
-    if not Path(TRAINING_CLI_ARGS_FILENAME).exists():
+    if not Path(training_cli_args_filepath).exists():
         raise FileNotFoundError(
-            f"File {TRAINING_CLI_ARGS_FILENAME} not found. Please create this file "
+            f"File {training_cli_args_filepath} not found. Please create this file "
             "with the command line arguments that were used to train the "
             "model."
         )
 
     try:
-        with open(TRAINING_CLI_ARGS_FILENAME, "r") as f:
+        with open(training_cli_args_filepath, "r") as f:
             yaml.safe_load(f)
     except yaml.YAMLError as e:
         raise ValueError(
-            f"File {TRAINING_CLI_ARGS_FILENAME} is not a valid yaml file. Please "
+            f"File {training_cli_args_filepath} is not a valid yaml file. Please "
             "check the file."
         ) from e
     # copy the file to the artifact output directory
+    fp_dst = Path(artifact_output_path) / TRAINING_CLI_ARGS_FILENAME
     shutil.copyfile(
-        TRAINING_CLI_ARGS_FILENAME,
-        Path(artifact_output_path) / TRAINING_CLI_ARGS_FILENAME,
+        training_cli_args_filepath, fp_dst
     )
-    logger.info(
-        f"Copied {TRAINING_CLI_ARGS_FILENAME} to "
-        f"{Path(artifact_output_path) / TRAINING_CLI_ARGS_FILENAME}"
-    )
+    logger.info(f"Copied {training_cli_args_filepath} to {fp_dst}")
 
 
 def _create_artifact_meta(artifact_output_path, nl_config_path, args):
@@ -320,6 +328,19 @@ def main():
         required=True,
         help="Path to the model checkpoint.",
     )
+    argparser.add_argument(
+        "--cli_training_args_filepath",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to file containing the command line arguments used to launch neural-lam during training."
+    )
+    argparser.add_argument(
+        "--skip_upload",
+        default=False,
+        action="store_true",
+        help="Skip uploading the inference artifact to the S3 host (this would be necessary on an airgapped system)",
+    )
 
     args = argparser.parse_args()
 
@@ -352,8 +373,9 @@ def main():
         args=args,
     )
 
-    _check_and_copy_training_cli_args(
-        artifact_output_path=artifact_output_path
+    _copy_training_cli_args(
+        artifact_output_path=artifact_output_path,
+        training_cli_args_filepath=args.cli_training_args_filepath
     )
 
     # create a zip file with everything in it
@@ -367,10 +389,17 @@ def main():
     fp_artifact_target = UPath(
         ARTIFACT_PATH_FORMAT.format(artifact_name=args.artifact_name)
     )
-    with open(fp_artifact_local, "rb") as f:
-        # Upload the zip file to the target location
-        logger.info(f"Uploading artifact to {fp_artifact_target}")
-        fp_artifact_target.write_bytes(f.read())
+    if not args.skip_upload:
+        with open(fp_artifact_local, "rb") as f:
+            # Upload the zip file to the target location
+            logger.info(f"Uploading artifact to {fp_artifact_target}")
+            fp_artifact_target.write_bytes(f.read())
+    else:
+        logger.info(
+            "You opted to skip uploading the inference artifact to the S3 host."
+            f" You will have to upload it to {fp_artifact_target} manually."
+        )
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I have worked out that the issue on #15 was that the path @khintz was providing didn't point to a neural-lam config, but rather the yaml-file that describes the command line arguments used during training. To make it clearer how `mlwm.build_inference_artifact` should be called I have added an explicit argument for the cli arguments yaml-file (called `cli_training_args_filepath`). I also made it possible to skip the upload of the inference artifact to S3 (since that isn't possible on an airgapped system). And finally, I updated the README so that it is a little clearer how the `mlwm-deployment` repository is organised and `mlwm` package works.